### PR TITLE
a better kubetools

### DIFF
--- a/kubetools.sh
+++ b/kubetools.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+CONTAINER_NAME=kubetools
+
+if [ "$(docker inspect -f '{{.State.Running}}' $CONTAINER_NAME 2> /dev/null )" == "" ]; then
+    docker run -it --name $CONTAINER_NAME       \
+        -v ~/.azure:/root/.azure                \
+        -v $PWD:/var/lib/src                   \
+        -v ~/.kube/config:/root/.kube/config    \
+        --rm -p 8001:8001                       \
+        --workdir /var/lib/src                  \
+        aimvector/kube-tools:latest
+else
+    docker exec -it $CONTAINER_NAME bash
+fi

--- a/kubetools.sh
+++ b/kubetools.sh
@@ -4,9 +4,10 @@ CONTAINER_NAME=kubetools
 if [ "$(docker inspect -f '{{.State.Running}}' $CONTAINER_NAME 2> /dev/null )" == "" ]; then
     docker run -it --name $CONTAINER_NAME       \
         -v ~/.azure:/root/.azure                \
-        -v $PWD:/var/lib/src                   \
+        -v $PWD:/var/lib/src                    \
         -v ~/.kube/config:/root/.kube/config    \
-        --rm -p 8001:8001                       \
+        --network=host                          \
+        --rm                        \
         --workdir /var/lib/src                  \
         aimvector/kube-tools:latest
 else

--- a/readme.md
+++ b/readme.md
@@ -44,6 +44,14 @@ helm --help
 az --help
 ```
 
+Alternatively, grab running the following command and get `kubetools` add to your `/usr/local/bin`
+
+```bash
+wget -qO https://raw.githubusercontent.com/marcel-dempers/kube-tools/master/kubetools.sh ~/kubetools
+chdmox +x ~/kubetools
+sudo mv ~/kubetools /usr/local/bin/kubetools
+```
+
 ## Build from source
 
 If you wish to customise it, you can build it from source:

--- a/readme.md
+++ b/readme.md
@@ -39,13 +39,13 @@ docker run -it --name kube-tools -v "$PWD":/var/lib/src -v /C/Users/docker/kube-
 Setup an alias for `kubetools`
 
 ```
-echo "alias kubetools='docker run -it --name kube-tools -v ~/.azure:/root/.azure -v \$PWD:/var/lib/src -v ~/.kube/config:/root/.kube/config --rm -p 8001:8001 --workdir /var/lib/src aimvector/kube-tools'" >> ~/.bashrc
+echo "alias kubetools='docker run -it --name kube-tools -v ~/.azure:/root/.azure -v \$PWD:/var/lib/src -v ~/.kube/config:/root/.kube/config --rm --network=host --workdir /var/lib/src aimvector/kube-tools'" >> ~/.bashrc
 
 ```
 Or just run the image:
 
 ```
-docker run -it --name kube-tools -v ~/.azure:/root/.azure -v $PWD:/var/lib/src -v ~/.kube/config:/root/.kube/config --rm -p 8001:8001 --workdir /var/lib/src aimvector/kube-tools
+docker run -it --name kube-tools -v ~/.azure:/root/.azure -v $PWD:/var/lib/src -v ~/.kube/config:/root/.kube/config --rm --network=host --workdir /var/lib/src aimvector/kube-tools
 ```
 
 Once in, you can access the tools:

--- a/readme.md
+++ b/readme.md
@@ -55,6 +55,14 @@ helm --help
 az --help
 ```
 
+Alternatively, grab running the following command and get `kubetools` add to your `/usr/local/bin`
+
+```bash
+wget -qO https://raw.githubusercontent.com/marcel-dempers/kube-tools/master/kubetools.sh ~/kubetools
+chdmox +x ~/kubetools
+sudo mv ~/kubetools /usr/local/bin/kubetools
+```
+
 ## Build from source
 
 If you wish to customise it, you can build it from source:


### PR DESCRIPTION
If a kubetools command is invoked, running kubetools a second time will through an error. If you need to reuse kubetools container instance in multiple terminal sessions. You will have to run `docker exec -i kube-tools` ...

How about this? Using new installation method and you just remember one command `kubetools` and keep it that way ;)

Last but not least, the most important fix addressed by this PR `kubectl port-foward` just work out of the box ;)